### PR TITLE
Collect multiple samples for relay test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ build-commands: ## <-- compiles executables to ${BUILD_DIR}
 	go build -o ${BUILD_DIR}/${RELAY_TEST_BINARY} ${RELAY_TEST_TARGET}
 
 build-lambda: ## <-- builds lambda function bundles in ${BUILD_DIR}
-	make lambda-pingtest
-	make lambda-relaytest
-	make lambda-cors
+	make build-lambda-pingtest
+	make build-lambda-relaytest
+	make build-lambda-cors
 
 build-lambda-pingtest: ## builds the pingtest lambda function
 	GOOS=linux go build -o ${BUILD_DIR}/${LAMBDA_PING_TEST_BINARY} ${LAMBDA_PING_TEST_TARGET}

--- a/cmd/relaytest/main.go
+++ b/cmd/relaytest/main.go
@@ -15,6 +15,7 @@ func main() {
 	nodeURL := flag.String("url", "", "node url")
 	nodeID := flag.String("id", "", "node id")
 	chainsArg := flag.String("chains", "", "comma separated chains ids, eg: -chains=0001,0003,0005")
+	numSamples := flag.Int64("num_samples", 5, "number of samples to collect")
 	flag.Parse()
 
 	if *nodeURL == "" || *nodeID == "" {
@@ -31,9 +32,10 @@ func main() {
 
 	ctx := context.Background()
 	req := relaying.RelayTestRequest{
-		NodeURL: *nodeURL,
-		NodeID:  *nodeID,
-		Chains:  chains,
+		NodeURL:    *nodeURL,
+		NodeID:     *nodeID,
+		Chains:     chains,
+		NumSamples: *numSamples,
 	}
 	response, err := relaying.HandleRequest(ctx, req)
 	if err != nil {

--- a/doc/node-checker-rpc.yml
+++ b/doc/node-checker-rpc.yml
@@ -80,6 +80,9 @@ paths:
                         items:
                           type: object
                           properties:
+                            duration_ms:
+                              type: number
+                              description: how long the request took to complete
                             status_code:
                               type: integer
                               description: the HTTP status code of the relay response
@@ -102,14 +105,10 @@ paths:
                     relay_responses: [
                       {
                         duration_ms: 59.941,
-                        response: {
-                          status_code: 200,
-                          data: {
-                            height: 52844
-
-                          }
+                        status_code: 200,
+                        data: {
+                          height: 52844
                         }
-
                       }
                     ]
 

--- a/doc/node-checker-rpc.yml
+++ b/doc/node-checker-rpc.yml
@@ -75,15 +75,17 @@ paths:
                           headers:
                             type: object
                             description: a key value pair map of additional headers that were sent in the RPC request
-                      relay_response:
-                        type: object
-                        properties:
-                          status_code:
-                            type: integer
-                            description: the HTTP status code of the relay response
-                          data:
-                            type: object
-                            description: the value of the relay response
+                      relay_responses:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            status_code:
+                              type: integer
+                              description: the HTTP status code of the relay response
+                            data:
+                              type: object
+                              description: the value of the relay response
                 example:
                   "0001":
                     chain_id: "0001"
@@ -97,12 +99,19 @@ paths:
                       method: "POST"
                       path: "/v1/query/height"
                       headers: null
-                    relay_response:
-                      status_code: 200
-                      data: {
-                        height: 52844
+                    relay_responses: [
+                      {
+                        duration_ms: 59.941,
+                        response: {
+                          status_code: 200,
+                          data: {
+                            height: 52844
+
+                          }
+                        }
 
                       }
+                    ]
 
 
   /ping-test:

--- a/relaying/handler.go
+++ b/relaying/handler.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	httpClientTimeoutSec = 20
+	maxNumSamples        = 50
+	defaultNumSamples    = 5
 )
 
 // RelayTestRequest represents the request format the relaying service accepts
@@ -51,7 +53,11 @@ func HandleRequest(ctx context.Context, req RelayTestRequest) (RelayTestResponse
 	}
 
 	if req.NumSamples == 0 {
-		req.NumSamples = 5
+		req.NumSamples = defaultNumSamples
+	}
+
+	if req.NumSamples > maxNumSamples {
+		return RelayTestResponse{}, fmt.Errorf("num_samples cannot exceed %d", maxNumSamples)
 	}
 
 	linter, err := NewNodeChecker(req.NodeID, req.NodeURL, req.Chains, &httpClient)

--- a/relaying/handler.go
+++ b/relaying/handler.go
@@ -2,8 +2,8 @@ package relaying
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"github.com/itsnoproblem/pokt-lint/pocket"
 	"github.com/itsnoproblem/pokt-lint/rpc"
 	nethttp "net/http"
 	"time"
@@ -28,14 +28,17 @@ type RelayTestResult struct {
 	Successful     bool              `json:"success"`
 	StatusCode     int               `json:"status_code"`
 	Message        string            `json:"message"`
-	DurationMS     float64           `json:"duration_ms"`
+	DurationAvgMS  float64           `json:"duration_avg_ms"`
+	DurationMinMS  float64           `json:"duration_min_ms"`
+	DurationMaxMS  float64           `json:"duration_max_ms"`
 	RelayRequest   rpc.Payload       `json:"relay_request"`
 	RelayResponses []RelayTestSample `json:"relay_responses"`
 }
 
 type RelayTestSample struct {
-	DurationMS    float64              `json:"duration_ms"`
-	RelayResponse pocket.RelayResponse `json:"response"`
+	DurationMS float64         `json:"duration_ms"`
+	StatusCode int             `json:"status_code"`
+	Data       json.RawMessage `json:"data"`
 }
 
 // RelayTestResponse is a map of chain ID to RelayTestResult

--- a/relaying/service_test.go
+++ b/relaying/service_test.go
@@ -18,7 +18,7 @@ func TestNodeChecker_RunRelayTests(t *testing.T) {
 		t.Fatalf("got error instantiating node checker: %s", err)
 	}
 
-	_, err = svc.RunRelayTests(context.Background())
+	_, err = svc.RunRelayTests(context.Background(), 5)
 	if err != nil {
 		t.Fatalf("got error running relay tests: %s", err)
 	}


### PR DESCRIPTION
Relay test will now collect more than one sample during a test run.  The number of samples can be specified in the call to the relay-test endpoint with the parameter `num_samples`

Also included here is a bug fix for #10 

This PR changes the format of the relay tests output:
```
{
    "0022": {
          "chain_id": "0022",
          "chain_name": "ETH Archival",
          "success": true,
          "status_code": 200,
          "message": "OK",
          "duration_avg_ms": 47.819,
          "duration_min_ms": 45.984,
          "duration_max_ms": 50.385,
          "relay_request": {
              "data": "{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"params\":[],\"id\":64}",
              "method": "POST",
              "path": "/",
              "headers": null
          },
          "relay_responses": [
              {
                  "duration_ms": 50.385,
                  "status_code": 200,
                  "data": "{\"jsonrpc\":\"2.0\",\"id\":64,\"result\":\"0x9e08fd\"}\n"
              },
              {
                  "duration_ms": 50.385,
                  "status_code": 200,
                  "data": "{\"jsonrpc\":\"2.0\",\"id\":64,\"result\":\"0x9e08fd\"}\n"
              }
        ]
    }
}    
```