### PR TITLE
Verifies simulateRelay is enabled, Improved request validation, clearer error messages

### DIFF
--- a/cmd/pingtest/main.go
+++ b/cmd/pingtest/main.go
@@ -30,7 +30,7 @@ func main() {
 	c := gohttp.Client{
 		Timeout: pingTimeoutMS * time.Millisecond,
 	}
-	client := http.NewClientWithLogger(&c, logger)
+	client := http.NewWebClient(c, logger)
 
 	ctx := context.Background()
 	svc, err := pinging.NewService(client, *nodeURL)

--- a/cmd/relaytest/main.go
+++ b/cmd/relaytest/main.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/itsnoproblem/pokt-lint/relaying"
 	"os"
 	"strings"
-)
 
-const httpClientTimeoutSec = 20
+	"github.com/itsnoproblem/pokt-lint/relaying"
+)
 
 func main() {
 	nodeURL := flag.String("url", "", "node url")

--- a/cmd/relaytest/main.go
+++ b/cmd/relaytest/main.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log"
+	nethttp "net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/itsnoproblem/pokt-lint/http"
 	"github.com/itsnoproblem/pokt-lint/relaying"
 )
+
+const httpClientTimeoutSec = 20
 
 func main() {
 	nodeURL := flag.String("url", "", "node url")
@@ -37,7 +43,13 @@ func main() {
 		Chains:     chains,
 		NumSamples: *numSamples,
 	}
-	response, err := relaying.HandleRequest(ctx, req)
+
+	c := nethttp.Client{
+		Timeout: httpClientTimeoutSec * time.Second,
+	}
+	httpClient := http.NewClientWithLogger(&c, log.Default())
+
+	response, err := relaying.HandleRequest(ctx, req, httpClient)
 	if err != nil {
 		fmt.Printf("Error from LambdaRelayTestHandler: %s", err)
 		os.Exit(9)

--- a/cmd/relaytest/main.go
+++ b/cmd/relaytest/main.go
@@ -5,14 +5,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
-	nethttp "net/http"
+	"github.com/itsnoproblem/pokt-lint/relaying"
 	"os"
 	"strings"
-	"time"
-
-	"github.com/itsnoproblem/pokt-lint/http"
-	"github.com/itsnoproblem/pokt-lint/relaying"
 )
 
 const httpClientTimeoutSec = 20
@@ -44,12 +39,7 @@ func main() {
 		NumSamples: *numSamples,
 	}
 
-	c := nethttp.Client{
-		Timeout: httpClientTimeoutSec * time.Second,
-	}
-	httpClient := http.NewClientWithLogger(&c, log.Default())
-
-	response, err := relaying.HandleRequest(ctx, req, httpClient)
+	response, err := relaying.HandleRequest(ctx, req)
 	if err != nil {
 		fmt.Printf("Error from LambdaRelayTestHandler: %s", err)
 		os.Exit(9)

--- a/http/client.go
+++ b/http/client.go
@@ -13,10 +13,11 @@ import (
 type Client interface {
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
+	Options(url string) (*http.Response, error)
 }
 
 // NewClientWithLogger returns a client that writes log messages
-func NewClientWithLogger(c Client, l *log.Logger) Client {
+func NewClientWithLogger(c *http.Client, l *log.Logger) Client {
 	return &clientWithLogger{
 		client: c,
 		logger: l,
@@ -24,7 +25,7 @@ func NewClientWithLogger(c Client, l *log.Logger) Client {
 }
 
 type clientWithLogger struct {
-	client Client
+	client *http.Client
 	logger *log.Logger
 }
 
@@ -49,6 +50,14 @@ func (c *clientWithLogger) Get(url string) (*http.Response, error) {
 	}
 	c.logInfo(fmt.Sprintf("%s: %s", url, t.Elapsed().String()))
 	return resp, nil
+}
+
+func (c *clientWithLogger) Options(url string) (*http.Response, error) {
+	req, err := http.NewRequest("OPTIONS", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Do(req)
 }
 
 func (c *clientWithLogger) logError(msg string, err error) {

--- a/http/client.go
+++ b/http/client.go
@@ -3,7 +3,7 @@ package http
 import (
 	"fmt"
 	"log"
-	"net/http"
+	nethttp "net/http"
 	"time"
 
 	"github.com/itsnoproblem/pokt-lint/timer"
@@ -11,29 +11,29 @@ import (
 
 // Client is an HTTP client.
 type Client interface {
-	Do(req *http.Request) (*http.Response, error)
-	Get(url string) (*http.Response, error)
-	Options(url string) (*http.Response, error)
+	Do(req *nethttp.Request) (*nethttp.Response, error)
+	Get(url string) (*nethttp.Response, error)
+	Options(url string) (*nethttp.Response, error)
 }
 
-// NewClientWithLogger returns a client that writes log messages
-func NewClientWithLogger(c *http.Client, l *log.Logger) Client {
-	return &clientWithLogger{
+// NewWebClient returns a client that writes log messages
+func NewWebClient(c nethttp.Client, l *log.Logger) Client {
+	return &webClient{
 		client: c,
 		logger: l,
 	}
 }
 
-type clientWithLogger struct {
-	client *http.Client
+type webClient struct {
+	client nethttp.Client
 	logger *log.Logger
 }
 
-func (c *clientWithLogger) Do(req *http.Request) (*http.Response, error) {
+func (c *webClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
 	t := timer.Start()
 	resp, err := c.client.Do(req)
 	if err != nil {
-		c.logError("clientWithLogger.Do", err)
+		c.logError("webClient.Do", err)
 		return resp, err
 	}
 
@@ -41,29 +41,29 @@ func (c *clientWithLogger) Do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (c *clientWithLogger) Get(url string) (*http.Response, error) {
+func (c *webClient) Get(url string) (*nethttp.Response, error) {
 	t := timer.Start()
 	resp, err := c.client.Get(url)
 	if err != nil {
-		c.logError("clientWithLogger.Get", err)
+		c.logError("webClient.Get", err)
 		return resp, err
 	}
 	c.logInfo(fmt.Sprintf("%s: %s", url, t.Elapsed().String()))
 	return resp, nil
 }
 
-func (c *clientWithLogger) Options(url string) (*http.Response, error) {
-	req, err := http.NewRequest("OPTIONS", url, nil)
+func (c *webClient) Options(url string) (*nethttp.Response, error) {
+	req, err := nethttp.NewRequest("OPTIONS", url, nil)
 	if err != nil {
 		return nil, err
 	}
 	return c.Do(req)
 }
 
-func (c *clientWithLogger) logError(msg string, err error) {
+func (c *webClient) logError(msg string, err error) {
 	c.logger.Printf("ERROR - %s - %s: %s", time.Now().String(), msg, err.Error())
 }
 
-func (c *clientWithLogger) logInfo(msg string) {
+func (c *webClient) logInfo(msg string) {
 	c.logger.Printf("INFO - %s - %s", time.Now().String(), msg)
 }

--- a/mock/http.go
+++ b/mock/http.go
@@ -1,12 +1,17 @@
 package mock
 
 import (
+	nethttp "net/http"
+
 	"github.com/itsnoproblem/pokt-lint/http"
-	gohttp "net/http"
 )
 
 type fakeHTTPClient struct {
 	returnSuccessResponses bool
+}
+
+func (c fakeHTTPClient) Options(url string) (*nethttp.Response, error) {
+	return c.fakeResponse()
 }
 
 // NewFakeHTTPClient returns a mock HTTP client
@@ -21,15 +26,15 @@ func (c fakeHTTPClient) ReturnSuccessResponses(newValue bool) http.Client {
 	return c
 }
 
-func (c fakeHTTPClient) Do(req *gohttp.Request) (*gohttp.Response, error) {
+func (c fakeHTTPClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
 	return c.fakeResponse()
 }
 
-func (c fakeHTTPClient) Get(url string) (*gohttp.Response, error) {
+func (c fakeHTTPClient) Get(url string) (*nethttp.Response, error) {
 	return c.fakeResponse()
 }
 
-func (c fakeHTTPClient) fakeResponse() (*gohttp.Response, error) {
+func (c fakeHTTPClient) fakeResponse() (*nethttp.Response, error) {
 	var statusCode int
 	var status string
 	if c.returnSuccessResponses {
@@ -40,7 +45,7 @@ func (c fakeHTTPClient) fakeResponse() (*gohttp.Response, error) {
 		status = "Internal Server Error"
 	}
 
-	res := gohttp.Response{
+	res := nethttp.Response{
 		Status:     status,
 		StatusCode: statusCode,
 	}

--- a/mock/http.go
+++ b/mock/http.go
@@ -10,31 +10,34 @@ type fakeHTTPClient struct {
 	returnSuccessResponses bool
 }
 
-func (c fakeHTTPClient) Options(url string) (*nethttp.Response, error) {
-	return c.fakeResponse()
-}
-
 // NewFakeHTTPClient returns a mock HTTP client
 func NewFakeHTTPClient(successResponses bool) http.Client {
-	return fakeHTTPClient{returnSuccessResponses: successResponses}
+	c := fakeHTTPClient{
+		returnSuccessResponses: successResponses,
+	}
+	return &c
 }
 
 // ReturnSuccessResponses determines the type of responses the client returns.
 // 200 OK if *true*, 500 Internal Server Error if *false*.
-func (c fakeHTTPClient) ReturnSuccessResponses(newValue bool) http.Client {
+func (c *fakeHTTPClient) ReturnSuccessResponses(newValue bool) http.Client {
 	c.returnSuccessResponses = newValue
 	return c
 }
 
-func (c fakeHTTPClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
+func (c *fakeHTTPClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
 	return c.fakeResponse()
 }
 
-func (c fakeHTTPClient) Get(url string) (*nethttp.Response, error) {
+func (c *fakeHTTPClient) Get(url string) (*nethttp.Response, error) {
 	return c.fakeResponse()
 }
 
-func (c fakeHTTPClient) fakeResponse() (*nethttp.Response, error) {
+func (c *fakeHTTPClient) Options(url string) (*nethttp.Response, error) {
+	return c.fakeResponse()
+}
+
+func (c *fakeHTTPClient) fakeResponse() (*nethttp.Response, error) {
 	var statusCode int
 	var status string
 	if c.returnSuccessResponses {

--- a/pinging/handler.go
+++ b/pinging/handler.go
@@ -28,7 +28,7 @@ func HandleRequest(ctx context.Context, req PingTestRequest) (PingTestResponse, 
 	httpClient := nethttp.Client{
 		Timeout: httpClientTimeoutSec * time.Second,
 	}
-	client := http.NewClientWithLogger(&httpClient, log.Default())
+	client := http.NewWebClient(httpClient, log.Default())
 	url := fmt.Sprintf("%s/v1", req.NodeURL)
 	pingSvc, err := NewService(client, url)
 	if err != nil {

--- a/pocket/provider.go
+++ b/pocket/provider.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/itsnoproblem/pokt-lint/http"
 	"io"
 	"log"
 	nethttp "net/http"
 	"strconv"
 	"strings"
+
+	"github.com/itsnoproblem/pokt-lint/http"
 )
 
 const (

--- a/pocket/provider.go
+++ b/pocket/provider.go
@@ -27,15 +27,14 @@ type Provider interface {
 	SimulateRelayIsEnabled() (bool, error)
 }
 
-type HTTPClient interface {
-	Do(req *nethttp.Request) (*nethttp.Response, error)
-	Get(url string) (*nethttp.Response, error)
-	Options(url string) (*nethttp.Response, error)
-}
+//type HTTPClient interface {
+//	Do(req *nethttp.Request) (*nethttp.Response, error)
+//	Get(url string) (*nethttp.Response, error)
+//	Options(url string) (*nethttp.Response, error)
+//}
 
 // NewProvider returns a new pocket provider
-func NewProvider(pocketURL string) Provider {
-	client := http.NewClientWithLogger(&nethttp.Client{}, log.Default())
+func NewProvider(pocketURL string, client http.Client) Provider {
 	return provider{
 		client:    client,
 		pocketURL: pocketURL,
@@ -43,7 +42,7 @@ func NewProvider(pocketURL string) Provider {
 }
 
 type provider struct {
-	client    HTTPClient
+	client    http.Client
 	pocketURL string
 }
 

--- a/pocket/provider.go
+++ b/pocket/provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	gohttp "net/http"
+	nethttp "net/http"
 	"strconv"
 	"strings"
 )
@@ -26,9 +26,9 @@ type Provider interface {
 }
 
 type HTTPClient interface {
-	Do(req *gohttp.Request) (*gohttp.Response, error)
-	Get(url string) (*gohttp.Response, error)
-	Options(url string) (*gohttp.Response, error)
+	Do(req *nethttp.Request) (*nethttp.Response, error)
+	Get(url string) (*nethttp.Response, error)
+	Options(url string) (*nethttp.Response, error)
 }
 
 // NewProvider returns a new pocket provider
@@ -118,7 +118,7 @@ func (p provider) SimulateRelayIsEnabled() (bool, error) {
 		return false, fmt.Errorf("SimulateRelayIsEnabled: %s", err)
 	}
 
-	if res.StatusCode != gohttp.StatusOK {
+	if res.StatusCode != nethttp.StatusOK {
 		return false, nil
 	}
 
@@ -136,7 +136,7 @@ func (p provider) doRequest(url string, reqObj interface{}) ([]byte, int, error)
 	}
 	req := bytes.NewBuffer(reqBody)
 
-	clientReq, err := gohttp.NewRequest(gohttp.MethodPost, url, req)
+	clientReq, err := nethttp.NewRequest(nethttp.MethodPost, url, req)
 	if err != nil {
 		return nil, 500, fmt.Errorf("doRequest got error creating request: %s", err)
 	}

--- a/pocket/provider.go
+++ b/pocket/provider.go
@@ -27,12 +27,6 @@ type Provider interface {
 	SimulateRelayIsEnabled() (bool, error)
 }
 
-//type HTTPClient interface {
-//	Do(req *nethttp.Request) (*nethttp.Response, error)
-//	Get(url string) (*nethttp.Response, error)
-//	Options(url string) (*nethttp.Response, error)
-//}
-
 // NewProvider returns a new pocket provider
 func NewProvider(pocketURL string, client http.Client) Provider {
 	return provider{

--- a/relaying/handler.go
+++ b/relaying/handler.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/itsnoproblem/pokt-lint/http"
+	"log"
+	nethttp "net/http"
+
 	"github.com/itsnoproblem/pokt-lint/pocket"
 	"github.com/itsnoproblem/pokt-lint/rpc"
 )
@@ -63,10 +67,13 @@ func HandleRequest(ctx context.Context, req RelayTestRequest) (RelayTestResponse
 	}
 
 	if err := req.Validate(); err != nil {
-		return RelayTestResponse{}, fmt.Errorf("Request was invalid: %s", err)
+		return RelayTestResponse{}, fmt.Errorf("request was invalid: %s", err)
 	}
 
-	pocketProvider := pocket.NewProvider(req.NodeURL)
+	client := nethttp.Client{}
+	loggingClient := http.NewWebClient(client, log.Default())
+	pocketProvider := pocket.NewProvider(req.NodeURL, loggingClient)
+
 	linter, err := NewNodeChecker(req.NodeID, req.NodeURL, req.Chains, pocketProvider)
 	if err != nil {
 		return RelayTestResponse{}, fmt.Errorf("relaying.HandleRequest: %s", err)

--- a/relaying/handler.go
+++ b/relaying/handler.go
@@ -25,6 +25,7 @@ type RelayTestRequest struct {
 	NumSamples int64    `json:"num_samples"`
 }
 
+// Validate ensures the validity of all required fields
 func (req RelayTestRequest) Validate() error {
 	if req.NodeID == "" && len(req.Chains) == 0 {
 		return fmt.Errorf("you must specify either 'node_id' or 'chain_ids'")
@@ -51,6 +52,7 @@ type RelayTestResult struct {
 	RelayResponses []RelayTestSample `json:"relay_responses"`
 }
 
+// RelayTestSample is an atomic relay test result
 type RelayTestSample struct {
 	DurationMS float64         `json:"duration_ms"`
 	StatusCode int             `json:"status_code"`

--- a/relaying/service_test.go
+++ b/relaying/service_test.go
@@ -14,7 +14,7 @@ func TestNodeChecker_RunRelayTests(t *testing.T) {
 	chains := []string{"0001"}
 
 	client := mock.NewFakeHTTPClient(true)
-	prv := pocket.NewProvider(client, "https://1.2.3.4:443")
+	prv := pocket.NewProvider("https://1.2.3.4:443", client)
 	svc, err := relaying.NewNodeChecker(nodeId, nodeAddress, chains, prv)
 	if err != nil {
 		t.Fatalf("got error instantiating node checker: %s", err)

--- a/relaying/service_test.go
+++ b/relaying/service_test.go
@@ -3,6 +3,7 @@ package relaying_test
 import (
 	"context"
 	"github.com/itsnoproblem/pokt-lint/mock"
+	"github.com/itsnoproblem/pokt-lint/pocket"
 	"github.com/itsnoproblem/pokt-lint/relaying"
 	"testing"
 )
@@ -13,7 +14,8 @@ func TestNodeChecker_RunRelayTests(t *testing.T) {
 	chains := []string{"0001"}
 
 	client := mock.NewFakeHTTPClient(true)
-	svc, err := relaying.NewNodeChecker(nodeId, nodeAddress, chains, client)
+	prv := pocket.NewProvider(client, "https://1.2.3.4:443")
+	svc, err := relaying.NewNodeChecker(nodeId, nodeAddress, chains, prv)
 	if err != nil {
 		t.Fatalf("got error instantiating node checker: %s", err)
 	}


### PR DESCRIPTION
Adds a method to the pocket provider, `SimulateRelayIsEnabled` and uses this to check that therelay endpoint is exposed and returns a `200 OK` http response.  This method sends an OPTIONS request to the `/v1/client/sim` endpoint.

Also improves request validation and clarifies some error messages. 

Fixes #11 