### PR TITLE
add DFK chain

### DIFF
--- a/pocket/chain.go
+++ b/pocket/chain.go
@@ -1,9 +1,5 @@
 package pocket
 
-import (
-	"fmt"
-)
-
 // Chain represents a pocket network chain as defined by https://docs.pokt.network/home/resources/references/supported-blockchains
 type Chain struct {
 	ID   string
@@ -13,6 +9,7 @@ type Chain struct {
 var allChains = map[string]string{
 	"0003": "AVAX",
 	"00A3": "AVAX Archival",
+	"03DF": "DeFi Kingdoms",
 	"0004": "BSC",
 	"0010": "BSC Archival",
 	"0021": "ETH",
@@ -42,7 +39,7 @@ var allChains = map[string]string{
 func ChainFromID(id string) (Chain, error) {
 	name, ok := allChains[id]
 	if !ok {
-		return Chain{}, fmt.Errorf("ChainFromID: unknown chain %s", id)
+		name = "Unknown"
 	}
 
 	return Chain{

--- a/relaying/handler.go
+++ b/relaying/handler.go
@@ -60,7 +60,7 @@ func HandleRequest(ctx context.Context, req RelayTestRequest) (RelayTestResponse
 		return RelayTestResponse{}, fmt.Errorf("num_samples cannot exceed %d", maxNumSamples)
 	}
 
-	linter, err := NewNodeChecker(req.NodeID, req.NodeURL, req.Chains, &httpClient)
+	linter, err := NewService(req.NodeID, req.NodeURL, req.Chains, &httpClient)
 	if err != nil {
 		return RelayTestResponse{}, fmt.Errorf("relaying.HandleRequest: %s", err)
 	}

--- a/relaying/service_test.go
+++ b/relaying/service_test.go
@@ -13,7 +13,7 @@ func TestNodeChecker_RunRelayTests(t *testing.T) {
 	chains := []string{"0001"}
 
 	client := mock.NewFakeHTTPClient(true)
-	svc, err := relaying.NewNodeChecker(nodeId, nodeAddress, chains, client)
+	svc, err := relaying.NewService(nodeId, nodeAddress, chains, client)
 	if err != nil {
 		t.Fatalf("got error instantiating node checker: %s", err)
 	}

--- a/rpc/payload.go
+++ b/rpc/payload.go
@@ -6,6 +6,7 @@ const (
 	pocketQueryHeight  = `{}`
 	btcGetBlockCount   = `{"jsonrpc":"1.0","id":"curltest","method":"getblockcount","params":[]}`
 	avaxIsBootstrapped = `{"jsonrpc":"2.0","id":1,"method":"info.isBootstrapped","params":{"chain":"X"}}`
+	avaxGetBlockchains = `{ "jsonrpc":"2.0", "id" :1, "method" :"platform.getBlockchains", "params" :{} }`
 	ethBlockNumber     = `{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":64}`
 	hmyBlockNumber     = `{"jsonrpc":"2.0","method":"hmy_blockNumber","params":[],"id":64}`
 	algoStatus         = `{}`
@@ -28,6 +29,8 @@ func NewPayload(chainID string) Payload {
 		return Payload{Method: http.MethodPost, Path: "/", Data: btcGetBlockCount}
 	case "0003":
 		return Payload{Method: http.MethodPost, Path: "/ext/info", Data: avaxIsBootstrapped}
+	case "03DF":
+		return Payload{Method: http.MethodPost, Path: "/ext/P", Data: avaxGetBlockchains}
 	case "0029":
 		return Payload{Method: http.MethodGet, Path: "/v2/status", Data: algoStatus}
 	case "0040":


### PR DESCRIPTION
- Adds support for DFK 
- Changes relay test behavior to not abort tests when an unknown chain is encountered
- Renames `relaying.nodeChecker` to `relaying.service`