### PR TITLE
Bugfix: simulate relay check fails if response is 204

### DIFF
--- a/pocket/provider.go
+++ b/pocket/provider.go
@@ -122,7 +122,7 @@ func (p provider) SimulateRelayIsEnabled() (bool, error) {
 		return false, fmt.Errorf("SimulateRelayIsEnabled: %s", err)
 	}
 
-	if res.StatusCode != nethttp.StatusOK {
+	if res.StatusCode != nethttp.StatusOK && res.StatusCode != nethttp.StatusNoContent {
 		return false, nil
 	}
 


### PR DESCRIPTION
The check to ensure simulateRelay is enabled makes an OPTIONS request to the /v1/client/sim rpc endpoint.  Currently it only considers a `200 OK` response as a success, but `204 No Content` is also valid, so this update accounts for those 204 responses.